### PR TITLE
fix: normalize file module specifier to file:// URLs

### DIFF
--- a/docs/src/denopack.config.ts
+++ b/docs/src/denopack.config.ts
@@ -6,10 +6,10 @@ const config: RollupOptions = {
   preserveEntrySignatures: false,
   plugins: [
     pluginRenderPagesAsHtml([
-      "src/pages/index.tsx",
-      "src/pages/scriptRunners.tsx",
-      "src/pages/cli.tsx",
-      "src/pages/plugins.tsx",
+      "./src/pages/index.tsx",
+      "./src/pages/scriptRunners.tsx",
+      "./src/pages/cli.tsx",
+      "./src/pages/plugins.tsx",
     ]),
   ],
   output: {

--- a/fixtures/cssBundle/basicCssEmit/denopack.config.ts
+++ b/fixtures/cssBundle/basicCssEmit/denopack.config.ts
@@ -3,7 +3,7 @@ import { pluginCssBundle as css, useCache } from "../../../mod.ts";
 import type { RollupOptions } from "../../../mod.ts";
 
 const config: RollupOptions = {
-  input: "src/mod.ts",
+  input: "./src/mod.ts",
   plugins: [
     css({ output: "css/output.css" }),
     ...useCache(),

--- a/fixtures/htmlBundle/basicJsAndCss/denopack.config.ts
+++ b/fixtures/htmlBundle/basicJsAndCss/denopack.config.ts
@@ -7,7 +7,7 @@ import {
 import type { RollupOptions } from "../../../mod.ts";
 
 const config: RollupOptions = {
-  input: "src/mod.ts",
+  input: "./src/mod.ts",
   plugins: [
     css({ output: "mod.css" }),
     html({

--- a/fixtures/htmlBundle/relativeUrls/denopack.config.ts
+++ b/fixtures/htmlBundle/relativeUrls/denopack.config.ts
@@ -7,7 +7,7 @@ import {
 import type { RollupOptions } from "../../../mod.ts";
 
 const config: RollupOptions = {
-  input: "src/mod.ts",
+  input: "./src/mod.ts",
   plugins: [
     css({ output: "mod.css" }),
     html({

--- a/plugin/fileLoader/mod.ts
+++ b/plugin/fileLoader/mod.ts
@@ -1,5 +1,6 @@
 import { path, Plugin } from "../../deps.ts";
 import { checkIntegrity } from "../../util/checkIntegrity.ts";
+import { isFileUrl } from "../../util/isFileUrl.ts";
 import { isHttpUrl } from "../../util/isHttpUrl.ts";
 
 export type Opts = {
@@ -14,8 +15,8 @@ export function pluginFileLoader(opts: Opts = {}): Plugin {
   return {
     name: "denopack-plugin-fileLoader",
     async load(id) {
-      if (!isHttpUrl(id)) {
-        return Deno.readTextFile(id.startsWith("file://") ? new URL(id) : id);
+      if (isFileUrl(id)) {
+        return Deno.readTextFile(new URL(id));
       }
 
       const response = await fetch(id);

--- a/plugin/fileLoader/mod.ts
+++ b/plugin/fileLoader/mod.ts
@@ -17,14 +17,14 @@ export function pluginFileLoader(opts: Opts = {}): Plugin {
     async load(id) {
       if (isFileUrl(id)) {
         return Deno.readTextFile(new URL(id));
+      } else if (isHttpUrl(id)) {
+        const response = await fetch(id);
+        const code = await response.text();
+
+        if (lockFile) checkIntegrity(lockFile, id, code);
+
+        return code;
       }
-
-      const response = await fetch(id);
-      const code = await response.text();
-
-      if (lockFile) checkIntegrity(lockFile, id, code);
-
-      return code;
     },
   };
 }

--- a/recipes/react-template/denopack.config.ts
+++ b/recipes/react-template/denopack.config.ts
@@ -22,7 +22,7 @@ function createHtmlTemplate(opts: TemplateOpts): Promise<string> {
 }
 
 const config: RollupOptions = {
-  input: "src/mod.tsx",
+  input: "./src/mod.tsx",
   plugins: [
     css({ output: "mod.css" }),
     html({

--- a/util/resolver.ts
+++ b/util/resolver.ts
@@ -5,13 +5,21 @@ export function resolver(
   importee: string,
   importer: string | undefined,
 ): string {
-  if (!importer) return importee;
-  else if (!usesProtocol(importee)) {
+  if (!importer) {
+    // If this is a raw absolute path, make it a `file:///` path.
+    if (!usesProtocol(importee) && path.isAbsolute(importee)) {
+      return new URL(`file:///${importee}`).toString();
+    }
+    return importee;
+  } else if (!usesProtocol(importee)) {
     // If this path is protocol prefixed, we can use URL to resolve it
     if (usesProtocol(importer)) return new URL(importee, importer).toString();
     // else if the path is absolute, return as is
-    if (path.isAbsolute(importee)) return importee;
+    if (path.isAbsolute(importee)) return resolver(importee, undefined);
     // else the path is relative, and we can resolve it by joining.
-    return path.join(path.parse(importer).dir, importee);
+    return resolver(
+      `file:///${path.join(path.parse(importer).dir, importee)}`,
+      undefined,
+    );
   } else return importee;
 }

--- a/util/resolver.ts
+++ b/util/resolver.ts
@@ -7,8 +7,13 @@ export function resolver(
 ): string {
   if (!importer) {
     // If this is a raw absolute path, make it a `file://` path.
-    if (!usesProtocol(importee) && path.isAbsolute(importee)) {
-      return new URL(`file:///${importee}`).toString();
+    if (!usesProtocol(importee)) {
+      // If path is absolute, just prefix with `file:///`
+      if (path.isAbsolute(importee)) {
+        return new URL(`file:///${importee}`).toString();
+      }
+      // else resolve based on Deno.cwd()
+      return new URL(`file:///${path.join(Deno.cwd(), importee)}`).toString();
     }
     return importee;
   } else if (!usesProtocol(importee)) {

--- a/util/resolver.ts
+++ b/util/resolver.ts
@@ -11,9 +11,15 @@ export function resolver(
       // If path is absolute, just prefix with `file:///`
       if (path.isAbsolute(importee)) {
         return new URL(`file:///${importee}`).toString();
+        // else if relative path resolve based on Deno.cwd()
+      } else if (
+        importee.startsWith("./") || importee.startsWith("../") ||
+        (Deno.build.os === "windows" && (
+          importee.startsWith(".\\") || importee.startsWith("..\\")
+        ))
+      ) {
+        return new URL(`file:///${path.join(Deno.cwd(), importee)}`).toString();
       }
-      // else resolve based on Deno.cwd()
-      return new URL(`file:///${path.join(Deno.cwd(), importee)}`).toString();
     }
     return importee;
   } else if (!usesProtocol(importee)) {

--- a/util/resolver.ts
+++ b/util/resolver.ts
@@ -6,7 +6,7 @@ export function resolver(
   importer: string | undefined,
 ): string {
   if (!importer) {
-    // If this is a raw absolute path, make it a `file:///` path.
+    // If this is a raw absolute path, make it a `file://` path.
     if (!usesProtocol(importee) && path.isAbsolute(importee)) {
       return new URL(`file:///${importee}`).toString();
     }


### PR DESCRIPTION
This resolves an issue where denopack and rollup don't consider `file:///mod.js` and `/mod.js` the same file. This likely has some crazy edge cases for certain crazy windows path, but deno can't deal with them either so :shrug:.