### PR TITLE
refactor: add context to transpile error

### DIFF
--- a/plugin/typescriptTransform/mod.ts
+++ b/plugin/typescriptTransform/mod.ts
@@ -8,7 +8,11 @@ export function pluginTypescriptTransform(opts?: Deno.CompilerOptions): Plugin {
     name: "denopack-plugin-typescriptTransform",
     async transform(code, id) {
       const unlock = await transpilerMutex.lock();
-      const result = await Deno.transpileOnly({ [id]: code }, opts);
+      const result = await Deno.transpileOnly({ [id]: code }, opts).catch(
+        (e) => {
+          throw new Error(`Failed to transpile ${id}: ${e}`);
+        },
+      );
       unlock();
       return { code: result[id].source, map: result[id].map };
     },


### PR DESCRIPTION
Currently you just get this terrible error:

```
Error: Error in TS compiler:
Error: Debug Failure. Output generation failed
    at Object.transpileModule (deno:cli/tsc/00_typescript.js:126901:29)
    at runtimeTranspile (deno:cli/tsc/99_main_compiler.js:1278:61)
    at tsCompilerOnMessage (deno:cli/tsc/99_main_compiler.js:1318:24)
    at <compiler>:1:12
```

Now the terrible error will at least let you know where it came from :-)