### PR TITLE
Throw error when config is undefined

### DIFF
--- a/cli/runBundler.ts
+++ b/cli/runBundler.ts
@@ -21,7 +21,7 @@ export async function runBundler(
     throw new Error([
       "Your configuration file does not export a valid configuration file as 'default'.",
       "Make sure your configuration file is not empty, and exports a configuration object.",
-    ].join('\n');
+    ].join('\n'));
   }
 
   if (

--- a/cli/runBundler.ts
+++ b/cli/runBundler.ts
@@ -16,7 +16,7 @@ export async function runBundler(
       ? `file://${path.join(Deno.cwd(), path.normalize(config))}`
       : "./options.ts"
   );
-  
+
   if (typeof conf !== "object") {
     throw new Error([
       "Your configuration file does not export a valid configuration file as 'default'.",

--- a/cli/runBundler.ts
+++ b/cli/runBundler.ts
@@ -20,7 +20,7 @@ export async function runBundler(
   if (typeof conf !== 'object') {
     throw new Error([
       "Your configuration file does not export a valid configuration file as 'default'.",
-      "Make sure your configuration file is not empty, and exports a configuration object."
+      "Make sure your configuration file is not empty, and exports a configuration object.",
     ].join('\n');
   }
 

--- a/cli/runBundler.ts
+++ b/cli/runBundler.ts
@@ -17,7 +17,7 @@ export async function runBundler(
       : "./options.ts"
   );
   
-  if (!conf) {
+  if (typeof conf !== 'object') {
     throw new Error([
       "Your configuration file does not export a valid configuration file as 'default'.",
       "Make sure your configuration file is not empty, and exports a configuration object."

--- a/cli/runBundler.ts
+++ b/cli/runBundler.ts
@@ -16,6 +16,13 @@ export async function runBundler(
       ? `file://${path.join(Deno.cwd(), path.normalize(config))}`
       : "./options.ts"
   );
+  
+  if (!conf) {
+    throw new Error([
+      "Your configuration file does not export a valid configuration file as 'default'.",
+      "Make sure your configuration file is not empty, and exports a configuration object."
+    ].join('\n');
+  }
 
   if (
     !!watchCache &&

--- a/cli/runBundler.ts
+++ b/cli/runBundler.ts
@@ -17,11 +17,11 @@ export async function runBundler(
       : "./options.ts"
   );
   
-  if (typeof conf !== 'object') {
+  if (typeof conf !== "object") {
     throw new Error([
       "Your configuration file does not export a valid configuration file as 'default'.",
       "Make sure your configuration file is not empty, and exports a configuration object.",
-    ].join('\n'));
+    ].join("\n"));
   }
 
   if (


### PR DESCRIPTION
Closes https://github.com/denofn/denopack/issues/42

When a configuration file doesn't export a configuration file as `default`, ensure the configuration actually exists (it isn't `undefined`).